### PR TITLE
HAPP-483 showing an alert to redirect to settings If the device doesn’t have any authentication turned on from device settings.

### DIFF
--- a/BCVaccineCard/BCVaccineCard/Utility/Constants/Strings/Strings.swift
+++ b/BCVaccineCard/BCVaccineCard/Utility/Constants/Strings/Strings.swift
@@ -275,10 +275,9 @@ extension String {
     static var useTouchId: String { return "UseTouchId".localized }
     static var usePassCode: String { return "UsePassCode".localized }
     static var useFaceId: String { return "UseFaceId".localized }
-    static var turnOnPasscode: String { return "TurnOnPasscode".localized }
-    static var turnOnFaceId: String { return "TurnOnFaceId".localized }
-    static var turnOnTouchId: String { return "TurnOnTouchId".localized }
-    
+    static var setupAuthentication: String { return "SetupAuthentication".localized }
+    static var allowSecurityAccessTitle: String { return "AllowSecurityAccessTitle".localized }
+    static var allowSecurityAccessMessage: String { return "AllowSecurityAccessMessage".localized }
 }
 
 // Accessibility only localized strings

--- a/BCVaccineCard/BCVaccineCard/Utility/Constants/Strings/en.lproj/Localizable.strings
+++ b/BCVaccineCard/BCVaccineCard/Utility/Constants/Strings/en.lproj/Localizable.strings
@@ -264,6 +264,6 @@
 "UseTouchId" = "Use Touch ID";
 "UsePassCode" = "Use passcode";
 "UseFaceId" = "Use Face ID";
-"TurnOnPasscode" = "Turn on passcode";
-"TurnOnFaceId" = "Turn on Face ID";
-"TurnOnTouchId" = "Turn on Touch ID";
+"AllowSecurityAccessTitle" = "Allow Security Access";
+"AllowSecurityAccessMessage" = "\nMy Health BC needs permission to use Touch ID and passcode for the device.\n\nGo to Settings > Touch ID & Passcode and change the settings to on.";
+"SetupAuthentication" = "Set up authentication";

--- a/BCVaccineCard/BCVaccineCard/Utility/LocalAuthentication/Local Auth View/LocalAuthVIew.swift
+++ b/BCVaccineCard/BCVaccineCard/Utility/LocalAuthentication/Local Auth View/LocalAuthVIew.swift
@@ -134,12 +134,12 @@ class LocalAuthView: UIView, Theme {
             useTouchIDButton.isHidden = true
         case .touchID:
             useTouchIDButton.isHidden = false
-            style(button: turnOnTouchIDButton, style: .Fill, title: .turnOnTouchId)
+            style(button: turnOnTouchIDButton, style: .Fill, title: .setupAuthentication)
             style(button: useTouchIDButton, style: .Fill, title: .useTouchId)
             hasBiometric = true
         case .faceID:
             useTouchIDButton.isHidden = false
-            style(button: turnOnTouchIDButton, style: .Fill, title: .turnOnFaceId)
+            style(button: turnOnTouchIDButton, style: .Fill, title: .setupAuthentication)
             style(button: useTouchIDButton, style: .Fill, title: .useFaceId)
             hasBiometric = true
         @unknown default:
@@ -164,7 +164,7 @@ class LocalAuthView: UIView, Theme {
         case .EnableAuthentication:
             turnOnTouchIDButton.isHidden = false
             if !hasBiometric {
-                turnOnTouchIDButton.setTitle(.turnOnPasscode, for: .normal)
+                turnOnTouchIDButton.setTitle(.setupAuthentication, for: .normal)
             }
             useTouchIDButton.isHidden = true
             usePasscodeButton.isHidden = true
@@ -181,7 +181,7 @@ class LocalAuthView: UIView, Theme {
         let underlineAttributedString = NSAttributedString(string: .learnMoreAboutLocalAuth, attributes: underlineAttribute)
         infoLabel.attributedText = underlineAttributedString
         
-        style(button: turnOnTouchIDButton, style: .Fill, title: .turnOnTouchId)
+        style(button: turnOnTouchIDButton, style: .Fill, title: .setupAuthentication)
         style(button: useTouchIDButton, style: .Fill, title: .useTouchId)
         style(button: usePasscodeButton, style: .Fill, title: .usePassCode)
         

--- a/BCVaccineCard/BCVaccineCard/Utility/LocalAuthentication/LocalAuthManager.swift
+++ b/BCVaccineCard/BCVaccineCard/Utility/LocalAuthentication/LocalAuthManager.swift
@@ -117,7 +117,9 @@ class LocalAuthManager {
     }
     
     private func openAuthSettings() {
-        UIApplication.openAppSettings()
+        self.view?.parent?.alertConfirmation(title: .allowSecurityAccessTitle, message: .allowSecurityAccessMessage, confirmTitle: .settings, confirmStyle: .default, onConfirm: {
+            UIApplication.openAppSettings()
+        },cancelTitle: .notNow, onCancel: {})
     }
     
     private func useAuth(policy: LAPolicy, completion: @escaping(_ status: AuthStatus) -> Void) {


### PR DESCRIPTION
Showing an alert to redirect to settings If the device doesn’t have any authentication turned on from device settings. 