### PR TITLE
change "allow security access" alert message according to available biometric type

### DIFF
--- a/BCVaccineCard/BCVaccineCard/Utility/Constants/Strings/Strings.swift
+++ b/BCVaccineCard/BCVaccineCard/Utility/Constants/Strings/Strings.swift
@@ -229,6 +229,7 @@ extension String {
     static var loginDescription: String { return "LoginDescription".localized }
     static var localAuthDescription: String { return "LocalAuthDescription".localized }
     static var touchId: String { return "TouchId".localized }
+    static var faceId: String { return "FaceId".localized }
     static var logoutTitle: String { return "LogoutTitle".localized }
     static var logoutDescription: String { return "LogoutDescription".localized }
     static var logOut: String { return "LogOut".localized }
@@ -277,7 +278,18 @@ extension String {
     static var useFaceId: String { return "UseFaceId".localized }
     static var setupAuthentication: String { return "SetupAuthentication".localized }
     static var allowSecurityAccessTitle: String { return "AllowSecurityAccessTitle".localized }
-    static var allowSecurityAccessMessage: String { return "AllowSecurityAccessMessage".localized }
+    static var allowSecurityAccessForFaceIdMessage: String {
+        return String(format: "AllowSecurityAccessMessage".localized, String.faceId, "and".localized, "\(String.faceId) & ")
+    }
+    static var allowSecurityAccessForTouchIdMessage: String {
+        return String(format: "AllowSecurityAccessMessage".localized, String.touchId, "and".localized, "\(String.touchId) & ")
+    }
+    static var allowSecurityAccessDefaultMessage: String {
+        return String(format: "AllowSecurityAccessMessage".localized, "", "", "")
+    }
+    static var reasonForRequestingAuthentication: String {
+        return "ReasonForRequestingAuthentication".localized
+    }
 }
 
 // Accessibility only localized strings

--- a/BCVaccineCard/BCVaccineCard/Utility/Constants/Strings/en.lproj/Localizable.strings
+++ b/BCVaccineCard/BCVaccineCard/Utility/Constants/Strings/en.lproj/Localizable.strings
@@ -184,6 +184,7 @@
 "LoginDescription" = "When logged in, recrods will be automatically added and updated";
 "LocalAuthDescription" = "When enabled, you can unlock the app with touch touch ID instead of passcode";
 "TouchId" = "Touch ID";
+"FaceId" = "Face ID";
 "DeleteAllRecordsAndSavedDataDescription" = "Log out of BC Services Card account and delete every records and saved personal information from My Health BC";
 "DeleteAllRecordsAndSavedData" = "Delete all records and saved data";
 "LogoutTitle" = "Log out of BC Service Card";
@@ -265,5 +266,7 @@
 "UsePassCode" = "Use passcode";
 "UseFaceId" = "Use Face ID";
 "AllowSecurityAccessTitle" = "Allow Security Access";
-"AllowSecurityAccessMessage" = "\nMy Health BC needs permission to use Touch ID and passcode for the device.\n\nGo to Settings > Touch ID & Passcode and change the settings to on.";
+"and" = " and ";
+"AllowSecurityAccessMessage" = "\nMy Health BC needs permission to use %@%@Passcode for the device.\n\nGo to Settings > %@Passcode and change the settings to on.";
 "SetupAuthentication" = "Set up authentication";
+"ReasonForRequestingAuthentication" = "Your records contain your personal infromation. Unlock My Health BC with biometric authentication.";

--- a/BCVaccineCard/BCVaccineCard/Utility/LocalAuthentication/LocalAuthManager.swift
+++ b/BCVaccineCard/BCVaccineCard/Utility/LocalAuthentication/LocalAuthManager.swift
@@ -120,7 +120,16 @@ class LocalAuthManager {
     }
     
     private func openAuthSettings() {
-        self.view?.parent?.alertConfirmation(title: .allowSecurityAccessTitle, message: .allowSecurityAccessMessage, confirmTitle: .settings, confirmStyle: .default, onConfirm: {
+        let message: String
+        switch biometricType {
+        case .touchID:
+            message = .allowSecurityAccessForTouchIdMessage
+        case .faceID:
+            message = .allowSecurityAccessForFaceIdMessage
+        default:
+            message = .allowSecurityAccessDefaultMessage
+        }
+        self.view?.parent?.alertConfirmation(title: .allowSecurityAccessTitle, message: message, confirmTitle: .settings, confirmStyle: .default, onConfirm: {
             UIApplication.openAppSettings()
         },cancelTitle: .notNow, onCancel: {})
     }
@@ -157,11 +166,10 @@ class LocalAuthManager {
     
     private func performAuth(policy: LAPolicy, completion: @escaping(_ status: AuthStatus) -> Void) {
         let context = LAContext()
-        let reason = "Your records contain your personal infromation. Unlock My Health BC with biometric authentication."
         var error: NSError?
         if context.canEvaluatePolicy(policy, error: &error) {
             LocalAuthManager.block = true
-            context.evaluatePolicy(policy, localizedReason: reason) {
+            context.evaluatePolicy(policy, localizedReason: .reasonForRequestingAuthentication) {
                 success, authenticationError in
                 DispatchQueue.main.async {
                     if success {


### PR DESCRIPTION
- #### Change "allow security access" alert message according to available biometric type
    -  If only Phone is touch ID → display Touch ID and Passcode on Alert text
    -  If only Phone is face ID → display Face ID and Passcode on Alert tex
- #### Add Localization for reason for requesting authentication